### PR TITLE
Fix typo in variable name

### DIFF
--- a/resources/systemmanagement/master/js/script.js
+++ b/resources/systemmanagement/master/js/script.js
@@ -484,7 +484,7 @@ function _validate_slots(element) {
                 if (depth) {
                     var int_val = parseInt(depth);
                     cur_slot *= int_val;
-                    if (cir_slot > slots || cur_slot == 0) {
+                    if (cur_slot > slots || cur_slot == 0) {
                         paper_input_container.invalid = true;
                         submit_btn.disabled = true;
                         return false;


### PR DESCRIPTION
In line 487 of script.js, the `cur_slot` variable at the left side of the OR had been mispelled.