### PR TITLE
Fix regression bug caused by 'depth' field introduction

### DIFF
--- a/resources/systemmanagement/master/index.jsp
+++ b/resources/systemmanagement/master/index.jsp
@@ -180,7 +180,7 @@
                                         <paper-input id="form_col" class="submit_work_form" name="cols" label="Columns" allowed-pattern="[0-9]" error-message="R x C value either it exceeds available slots or it is zero!" onInput="_validate_slots(this)"></paper-input>
                                     </td>
                                     <td>
-										<paper-input id="form_dep" class="submit_work_form" name="depth" label="Depth" allowed-pattern="[0-9]" error-message="R x C x D value either exceeds available slots or is zero!" onInput="_validate_slots(this)"></paper-input>
+										<paper-input disabled id="form_dep" class="submit_work_form" name="depth" label="Depth" allowed-pattern="[0-9]" error-message="R x C x D value either exceeds available slots or is zero!" onInput="_validate_slots(this)"></paper-input>
 									</td>
                                 </tr>
                                 <tr>

--- a/resources/systemmanagement/master/js/script.js
+++ b/resources/systemmanagement/master/js/script.js
@@ -506,6 +506,9 @@ function submitForm() {
     // get the submit button and
     // start the progress animation
     submitSimulationButton = document.getElementById("submit_btn");
+    if (!simProgress) {
+        simProgress = document.getElementById("simulation-progress");
+    }
     startProgress(simProgress, submitSimulationButton);
 
     $(form).unbind('submit').bind("submit", _OnsubmitSimulation);
@@ -545,6 +548,7 @@ function checkForm(form) {
                             success = false;
                         }
                         break;
+
                     case "rows":
                         if (partitioning.toLowerCase() == 'uniform') {
                             $(error_toast_message).html(
@@ -554,6 +558,7 @@ function checkForm(form) {
                             success = false;
                         }
                         break;
+
                     case "columns":
                         if (partitioning.toLowerCase() == 'uniform') {
                             $(error_toast_message).html(
@@ -563,6 +568,17 @@ function checkForm(form) {
                             success = false;
                         }
                         break;
+
+                    case "depth":
+                    if (partitioning.toLowerCase() == 'three-dim') {
+                        $(error_toast_message).html(
+                            "You should fill the <strong>" + paper_input.label + "</strong> field."
+                        );
+                        error_toast.open();
+                        success = false;
+                    }
+                    break;
+
                     default:
                         $(error_toast_message).html(
                             "You should fill the <strong>" + paper_input.label + "</strong> field."


### PR DESCRIPTION
'depth' field in simulation request panel was not properly shown and checked: it appeared at the opening of the dialog with 'uniform' type selected; moreover, it was not checked anyway when submitting the simulation request.